### PR TITLE
Add playwright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,25 +9,34 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         node-version: [22.x]
-        
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-        
+
     - name: Install dependencies
-      run: npm ci
-      
+      run: |
+        npm ci
+        npx playwright install --with-deps chromium
+        npx playwright install-deps chromium
+
     - name: Run prepare
       run: npm run prepare
-      
+
     - name: Run tests
       run: npm run test
+
+    - name: Run e2e tests
+      env:
+        CI: 1
+        FORCE_COLOR: 1
+      run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ coverage
 .idea
 .DS_Store
 .publish
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,8 @@
         "@babel/core": "^7.21.4",
         "@babel/preset-env": "^7.21.4",
         "@babel/register": "^7.21.4",
+        "@playwright/test": "^1.52.0",
+        "@types/node": "^22.15.0",
         "babel-plugin-module-resolver": "^4.1.0",
         "chai": "~3.4.1",
         "conventional-changelog": "^5.0.0",
@@ -1717,6 +1719,22 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@textlint/ast-node-types": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.4.3.tgz",
@@ -1783,8 +1801,8 @@
       "version": "22.15.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.0.tgz",
       "integrity": "sha512-99S8dWD2DkeE6PBaEDw+In3aar7hdoBvjyJMR6vaKBTzpvR0P00ClzJMOoVrj9D2+Sy/YCwACYHnBTpMhg1UCA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -18798,6 +18816,53 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/pleeease-filters": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-1.0.1.tgz",
@@ -25459,8 +25524,8 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unherit": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "test:unit": "mocha --require @babel/register 'test/unit/**/*.js'",
     "test:integration": "mocha --require @babel/register 'test/integration/**/*.js'",
     "test:functional": "karma start test/karma.conf.js --single-run --reporters mocha",
+    "test:e2e": "playwright test",
     "test": "npm run test:unit && npm run test:integration",
     "spellcheck": "yaspeller-ci README.md DEVELOPMENT.md",
     "prepare": "gulp build",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "@babel/core": "^7.21.4",
     "@babel/preset-env": "^7.21.4",
     "@babel/register": "^7.21.4",
+    "@playwright/test": "^1.52.0",
+    "@types/node": "^22.15.0",
     "babel-plugin-module-resolver": "^4.1.0",
     "chai": "~3.4.1",
     "conventional-changelog": "^5.0.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,81 @@
+// @ts-check
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './test/e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run demo',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});
+

--- a/test/e2e/styleguide.spec.js
+++ b/test/e2e/styleguide.spec.js
@@ -1,0 +1,16 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('http://localhost:3000/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/SC5 Styleguide/);
+});
+
+test('get started link', async ({ page }) => {
+  await page.goto('http://localhost:3000/');
+
+  // Expects page to have a heading with the name of the project
+  await expect(page.getByRole('heading', { name: 'SC5 style guide generator' })).toBeVisible();
+});


### PR DESCRIPTION
This pull request introduces end-to-end (e2e) testing using Playwright, along with necessary configuration and dependencies. The changes include setting up the Playwright framework, adding e2e test scripts, and updating the CI workflow to include e2e tests.

### End-to-End Testing Setup:
* Added `playwright.config.js` to configure Playwright with settings like test directory, retries, browser projects (e.g., Chromium), and a local development server (`npm run demo`) for testing.
* Created a new e2e test file `test/e2e/styleguide.spec.js` with basic tests for checking the page title and visibility of the main heading.

### Dependency Updates:
* Added `@playwright/test` and `@types/node` as new dependencies in `package.json`.

### Script Updates:
* Added a new npm script `test:e2e` in `package.json` to execute Playwright tests.

### CI Workflow Enhancements:
* Updated `.github/workflows/test.yml` to install Playwright dependencies, start the demo server, and run e2e tests as part of the CI pipeline.