### PR TITLE
Update bundling configuration for highlight.js wrappers

### DIFF
--- a/.github/prompts/202505141526.md
+++ b/.github/prompts/202505141526.md
@@ -1,0 +1,25 @@
+# highlight.js のラッパーファイルをバンドル設定の修正
+
+## 目的
+- `lib/app/js/vendor/highlight-languages.js` 及び `lib/app/js/vendor/highlight-languages-wrapper.js` を `gulpfile.babel.js` の `jsVendor` タスクでバンドルするよう修正
+- `demo-gulpfile.js` からは該当コードを削除しても、デモ環境で正常に動作するようにする
+
+## 実施内容
+1. `gulpfile.babel.js` の `jsVendor` タスクを確認
+   - 既にハイライト言語のラッパーとレジストレーションファイルがバンドルされていることを確認
+
+2. `demo-gulpfile.js` から不要なコードを削除
+   - `styleguide:highlight` タスクから言語ラッパー関連のコードを削除
+   - `styleguide:vendor` タスクから言語ラッパー関連のコードを削除
+   - 両タスクとも、highlight.js のコア機能と言語モジュール自体は保持
+
+3. デモ環境を起動して動作テスト
+   - `npm run demo` で正常に動作することを確認
+
+## 結果
+- highlight.js のラッパーとレジストレーション機能は `gulpfile.babel.js` の `jsVendor` タスクにより提供され、デモ環境でも正常に機能することを確認した
+
+## 課題と解決策
+- デモ環境では、`highlight-languages.js` と `highlight-languages-wrapper.js` は `demo-gulpfile.js` のみでバンドルされていたが、これを `gulpfile.babel.js` でバンドルするよう修正
+- `gulpfile.babel.js` の設定を見直し、既にこれらのファイルをバンドルする仕組みが整っていることを確認
+- `demo-gulpfile.js` から関連するコードを削除し、デモ環境が正常に動作することを検証

--- a/demo-gulpfile.js
+++ b/demo-gulpfile.js
@@ -144,14 +144,9 @@ gulp.task('styleguide:highlight', function() {
   ])
   .pipe(gulp.dest(outputPath + '/js/highlight/languages'));
   
-  // サポートスクリプトをコピー
-  const hljsWrappers = gulp.src([
-    'lib/app/js/vendor/highlight-languages-wrapper.js',
-    'lib/app/js/vendor/highlight-languages.js'
-  ])
-  .pipe(gulp.dest(outputPath + '/js/highlight'));
+  // サポートスクリプトは gulpfile.babel.js で処理されるため削除
   
-  return merge(hljs, hljsLanguages, hljsWrappers);
+  return merge(hljs, hljsLanguages);
 });
 
 // vendor.js のビルド
@@ -177,11 +172,7 @@ gulp.task('styleguide:vendor', function() {
     'node_modules/highlight.js/lib/languages/python.js'
   ]);
   
-  // 言語モジュールをグローバル変数にエクスポートするスクリプトと登録スクリプト
-  const hljsWrappers = gulp.src([
-    'lib/app/js/vendor/highlight-languages-wrapper.js',
-    'lib/app/js/vendor/highlight-languages.js'
-  ]);
+  // 言語モジュールをグローバル変数にエクスポートするスクリプトと登録スクリプトは gulpfile.babel.js で処理されるため削除
   
   // その他のAngularモジュール
   const angularModules = gulp.src([
@@ -189,7 +180,7 @@ gulp.task('styleguide:vendor', function() {
   ]);
   
   // すべてのストリームを順番に結合
-  return merge(hljs, hljsLanguages, hljsWrappers, angularModules)
+  return merge(hljs, hljsLanguages, angularModules)
     .pipe(concat('vendor.js'))
     .pipe(gulp.dest(outputPath + '/js'));
 });

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -54,7 +54,6 @@ function jsApp() {
 function jsVendor() {
   return gulp.src([
     'node_modules/lodash/lodash.js', // Lodash を最初の方で読み込む
-    'lib/app/js/vendor/**/*.js', // Keep existing vendor files
     'node_modules/highlight.js/lib/highlight.js',
     // highlight.js言語モジュールを明示的に読み込む
     'node_modules/highlight.js/lib/languages/bash.js',
@@ -69,6 +68,11 @@ function jsVendor() {
     'node_modules/highlight.js/lib/languages/php.js',
     'node_modules/highlight.js/lib/languages/ruby.js',
     'node_modules/highlight.js/lib/languages/python.js',
+    // highlight.js 言語ラッパーとレジストレーションファイル
+    'lib/app/js/vendor/highlight-languages-wrapper.js',
+    'lib/app/js/vendor/highlight-languages.js',
+    // その他のベンダーファイル
+    'lib/app/js/vendor/**/*.js', // Keep existing vendor files
     'node_modules/angular/angular.js',
     'node_modules/angular-animate/angular-animate.js',
     'node_modules/angular-highlightjs/build/angular-highlightjs.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nanasess-sc5-styleguide",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nanasess-sc5-styleguide",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "angular": "^1.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanasess-sc5-styleguide",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Styleguide generator is a handy little tool that helps you generate good looking styleguides from stylesheets using KSS notation.",
   "bin": {
     "styleguide": "./bin/styleguide"


### PR DESCRIPTION
This pull request refactors the handling of `highlight.js` language wrappers and registration files by centralizing their bundling in `gulpfile.babel.js` and cleaning up redundant code in `demo-gulpfile.js`. Additionally, the project version in `package.json` has been incremented to reflect these changes.

### Refactoring of `highlight.js` bundling:

* [`gulpfile.babel.js`](diffhunk://#diff-7291edac743a0e6f594d817cb46f00cb3866bf89f40569ae494e36c1b722afa8R71-R75): Updated the `jsVendor` task to explicitly include `highlight-languages-wrapper.js` and `highlight-languages.js` for bundling, ensuring all necessary files are processed in one place.

* [`demo-gulpfile.js`](diffhunk://#diff-b8c238b2e5d1d7e7dac8a78a4b617754d63b282ed03ce1f8997eb59068aa2e81L147-R149): Removed redundant code related to `highlight.js` language wrappers and registration files from the `styleguide:highlight` and `styleguide:vendor` tasks, as these are now handled in `gulpfile.babel.js`. [[1]](diffhunk://#diff-b8c238b2e5d1d7e7dac8a78a4b617754d63b282ed03ce1f8997eb59068aa2e81L147-R149) [[2]](diffhunk://#diff-b8c238b2e5d1d7e7dac8a78a4b617754d63b282ed03ce1f8997eb59068aa2e81L180-R183)

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Incremented the project version from `4.1.0` to `4.1.1` to reflect the changes made in this update.