### PR TITLE
fix: npm run demo:cleanup のエラーを修正

### DIFF
--- a/demo-gulpfile.js
+++ b/demo-gulpfile.js
@@ -7,11 +7,11 @@ var gulp = require('gulp'),
   { series, parallel, watch } = require('gulp'), // Added
   source = 'lib/app/css/*.css',
   outputPath = 'demo-output',
-  { deleteAsync } = require('del'); // 修正: del v8以降はdeleteAsyncを使用
+  del = require('del'); // del v6.1.1を使用
 
 // クリーンアップタスク
 gulp.task('clean', function() {
-  return deleteAsync([
+  return del([
     'lib/app/js/components/*',
     'lib/dist/*',
     'demo-output/*'


### PR DESCRIPTION
## 概要

`npm run demo:cleanup` で発生する `deleteAsync is not a function` エラーを修正しました。

## 変更内容

- del v6.1.1では`deleteAsync`ではなく`del`関数を使用するように修正

Closes #56

Generated with [Claude Code](https://claude.ai/code)